### PR TITLE
sample_articlesの雛形をscaffoldコマンドにより作成、migrationの実行

### DIFF
--- a/app/controllers/sample_articles_controller.rb
+++ b/app/controllers/sample_articles_controller.rb
@@ -1,0 +1,70 @@
+class SampleArticlesController < ApplicationController
+  before_action :set_sample_article, only: %i[ show edit update destroy ]
+
+  # GET /sample_articles or /sample_articles.json
+  def index
+    @sample_articles = SampleArticle.all
+  end
+
+  # GET /sample_articles/1 or /sample_articles/1.json
+  def show
+  end
+
+  # GET /sample_articles/new
+  def new
+    @sample_article = SampleArticle.new
+  end
+
+  # GET /sample_articles/1/edit
+  def edit
+  end
+
+  # POST /sample_articles or /sample_articles.json
+  def create
+    @sample_article = SampleArticle.new(sample_article_params)
+
+    respond_to do |format|
+      if @sample_article.save
+        format.html { redirect_to sample_article_url(@sample_article), notice: "Sample article was successfully created." }
+        format.json { render :show, status: :created, location: @sample_article }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @sample_article.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /sample_articles/1 or /sample_articles/1.json
+  def update
+    respond_to do |format|
+      if @sample_article.update(sample_article_params)
+        format.html { redirect_to sample_article_url(@sample_article), notice: "Sample article was successfully updated." }
+        format.json { render :show, status: :ok, location: @sample_article }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @sample_article.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /sample_articles/1 or /sample_articles/1.json
+  def destroy
+    @sample_article.destroy
+
+    respond_to do |format|
+      format.html { redirect_to sample_articles_url, notice: "Sample article was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_sample_article
+      @sample_article = SampleArticle.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def sample_article_params
+      params.require(:sample_article).permit(:title, :content)
+    end
+end

--- a/app/models/sample_article.rb
+++ b/app/models/sample_article.rb
@@ -1,0 +1,2 @@
+class SampleArticle < ApplicationRecord
+end

--- a/app/views/sample_articles/_form.html.erb
+++ b/app/views/sample_articles/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: sample_article) do |form| %>
+  <% if sample_article.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(sample_article.errors.count, "error") %> prohibited this sample_article from being saved:</h2>
+
+      <ul>
+        <% sample_article.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :content %>
+    <%= form.text_area :content %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/sample_articles/edit.html.erb
+++ b/app/views/sample_articles/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Sample Article</h1>
+
+<%= render 'form', sample_article: @sample_article %>
+
+<%= link_to 'Show', @sample_article %> |
+<%= link_to 'Back', sample_articles_path %>

--- a/app/views/sample_articles/index.html.erb
+++ b/app/views/sample_articles/index.html.erb
@@ -1,0 +1,29 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Sample Articles</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th>Content</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @sample_articles.each do |sample_article| %>
+      <tr>
+        <td><%= sample_article.title %></td>
+        <td><%= sample_article.content %></td>
+        <td><%= link_to 'Show', sample_article %></td>
+        <td><%= link_to 'Edit', edit_sample_article_path(sample_article) %></td>
+        <td><%= link_to 'Destroy', sample_article, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Sample Article', new_sample_article_path %>

--- a/app/views/sample_articles/new.html.erb
+++ b/app/views/sample_articles/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Sample Article</h1>
+
+<%= render 'form', sample_article: @sample_article %>
+
+<%= link_to 'Back', sample_articles_path %>

--- a/app/views/sample_articles/show.html.erb
+++ b/app/views/sample_articles/show.html.erb
@@ -1,0 +1,14 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Title:</strong>
+  <%= @sample_article.title %>
+</p>
+
+<p>
+  <strong>Content:</strong>
+  <%= @sample_article.content %>
+</p>
+
+<%= link_to 'Edit', edit_sample_article_path(@sample_article) %> |
+<%= link_to 'Back', sample_articles_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
+  resources :sample_articles
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20240306124645_create_sample_articles.rb
+++ b/db/migrate/20240306124645_create_sample_articles.rb
@@ -1,0 +1,10 @@
+class CreateSampleArticles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :sample_articles do |t|
+      t.string :title
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,25 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2024_03_06_124645) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "sample_articles", force: :cascade do |t|
+    t.string "title"
+    t.text "content"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end


### PR DESCRIPTION
# 概要
- scaffoldコマンドによるsample_articles雛形の作成
- `rails db:migrate`によるmigrationの実行