### PR TITLE
i18nによる日本語化の対応実施

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,3 +49,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'rails-i18n', '~> 6.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.1.7.6)
       actionpack (= 6.1.7.6)
       activesupport (= 6.1.7.6)
@@ -218,6 +221,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.7, >= 6.1.7.1)
+  rails-i18n (~> 6.0.0)
   sass-rails (>= 6)
   spring
   turbolinks (~> 5)

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -1,6 +1,6 @@
-<h1>Editing Article</h1>
+<h1><%= t('common.Editing Article') %></h1>
 
 <%= render 'form', article: @article %>
 
-<%= link_to 'Show', @article %> |
-<%= link_to 'Back', articles_path %>
+<%= link_to t('common.Show'), @article %> |
+<%= link_to t('common.Back'), articles_path %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,12 +1,12 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Articles</h1>
+<h1><%= t('common.Articles') %></h1>
 
 <table>
   <thead>
     <tr>
-      <th>Title</th>
-      <th>Content</th>
+      <th><%= t('common.Title') %></th>
+      <th><%= t('common.Content') %></th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -16,9 +16,9 @@
       <tr>
         <td><%= article.title %></td>
         <td><%= article.content %></td>
-        <td><%= link_to 'Show', article %></td>
-        <td><%= link_to 'Edit', edit_article_path(article) %></td>
-        <td><%= button_to "Destroy", article, method: :delete %></td>
+        <td><%= link_to t('common.Show'), article %></td>
+        <td><%= link_to t('common.Edit'), edit_article_path(article) %></td>
+        <td><%= button_to t('common.Destroy'), article, method: :delete %></td>
       </tr>
     <% end %>
   </tbody>
@@ -26,4 +26,4 @@
 
 <br>
 
-<%= link_to 'New Article', new_article_path %>
+<%= link_to t('common.New Article'), new_article_path %>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,5 +1,5 @@
-<h1>New Article</h1>
+<h1><%= t('common.New Article') %></h1>
 
 <%= render 'form', article: @article %>
 
-<%= link_to 'Back', articles_path %>
+<%= link_to t('common.Back'), articles_path %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -10,5 +10,5 @@
   <%= @article.content %>
 </p>
 
-<%= link_to 'Edit', edit_article_path(@article) %> |
-<%= link_to 'Back', articles_path %>
+<%= link_to t('common.Edit'), edit_article_path(@article) %> |
+<%= link_to t('common.Back'), articles_path %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,10 @@ module WonderfulPostApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 
+    config.time_zone = 'Tokyo'
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,8 @@
+ja:
+    activerecord:
+     models:
+       article: '記事'
+     attributes:
+       article:
+         title: 'タイトル'
+         content: '本文'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,11 @@
+ja:
+  common:
+    Articles: '記事'
+    Title: 'タイトル'
+    Content: '本文'
+    Show: '詳細'
+    Back: '戻る'
+    Edit: '編集'
+    Destroy: '削除'
+    New Article: '記事作成'
+    Editing Article: '記事編集'


### PR DESCRIPTION
# 概要
- `gem 'rails-i18n'`のインストール
- `config/application.rb`の日本語化対応
- 日本語化に対応した`ja.yml`ファイルの追加
- コントローラー及びビューの日本語化対応