### PR TITLE
記事及びユーザーの関連付けの実装

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,7 @@
 class Article < ApplicationRecord
   validates :title, presence: true
   validates :content, presence: true
+
+  belongs_to :user
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :articles
+
 end

--- a/db/migrate/20240420125652_add_user_id_to_articles.rb
+++ b/db/migrate/20240420125652_add_user_id_to_articles.rb
@@ -1,0 +1,5 @@
+class AddUserIdToArticles < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :articles, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_16_111739) do
+ActiveRecord::Schema.define(version: 2024_04_20_125652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 2024_04_16_111739) do
     t.text "content"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
   create_table "sample_articles", force: :cascade do |t|
@@ -41,4 +43,5 @@ ActiveRecord::Schema.define(version: 2024_04_16_111739) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "articles", "users"
 end


### PR DESCRIPTION
# 概要
- Articlesテーブルへ外部キーとしてuser_idカラムの追加
- Userモデル及びArticleモデルにおける1対多の関係性の追加