### PR TITLE
記事及びタグの関連付けの実装

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,4 +4,7 @@ class Article < ApplicationRecord
 
   belongs_to :user
 
+  has_many :article_tags, dependent: :destroy
+  has_many :tags, through: :article_tags
+
 end

--- a/app/models/article_tag.rb
+++ b/app/models/article_tag.rb
@@ -1,0 +1,4 @@
+class ArticleTag < ApplicationRecord
+  belongs_to :article
+  belongs_to :tag
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,7 @@
 class Tag < ApplicationRecord
   validates :name, presence: true, uniqueness: true
+
+  has_many :article_tags, dependent: :destroy
+  has_many :articles, through: :article_tags
+
 end

--- a/db/migrate/20240612175939_create_article_tags.rb
+++ b/db/migrate/20240612175939_create_article_tags.rb
@@ -1,0 +1,10 @@
+class CreateArticleTags < ActiveRecord::Migration[6.1]
+  def change
+    create_table :article_tags do |t|
+      t.references :article, foreign_key: true
+      t.references :tag, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_06_11_210832) do
+ActiveRecord::Schema.define(version: 2024_06_12_175939) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "article_tags", force: :cascade do |t|
+    t.bigint "article_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_article_tags_on_article_id"
+    t.index ["tag_id"], name: "index_article_tags_on_tag_id"
+  end
 
   create_table "articles", force: :cascade do |t|
     t.string "title"
@@ -42,5 +51,7 @@ ActiveRecord::Schema.define(version: 2024_06_11_210832) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "article_tags", "articles"
+  add_foreign_key "article_tags", "tags"
   add_foreign_key "articles", "users"
 end


### PR DESCRIPTION
## 概要
- `ArticleTag`モデル及び中間テーブル（`article_tags`）の実装
- `articles`テーブル及び`tags`テーブルの多対多の関係性の実装